### PR TITLE
build tailscale from source.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,17 +2,21 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM mcr.microsoft.com/vscode/devcontainers/universal:linux
+FROM mcr.microsoft.com/vscode/devcontainers/universal:linux as builder
+USER root
 
+WORKDIR /go/src/tailscale
+COPY . ./
+RUN git clone https://github.com/tailscale/tailscale.git && cd tailscale && \
+    git checkout dgentry/dns-copy && go mod download && \
+    go install -mod=readonly ./cmd/tailscaled ./cmd/tailscale
+COPY . ./
+
+FROM mcr.microsoft.com/vscode/devcontainers/universal:linux
 USER root
 
 COPY tailscaled /etc/init.d
+COPY --from=builder /go/bin/tailscaled /usr/sbin/tailscaled
+COPY --from=builder /go/bin/tailscale /usr/bin/tailscale
 
-RUN apt update && apt install -y curl gpg
-
-RUN curl https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | apt-key add
-RUN curl https://pkgs.tailscale.com/stable/ubuntu/focal.list | tee /etc/apt/sources.list.d/tailscale.list
-RUN apt update && \
-    export DEBIAN_FRONTEND=noninteractive && \
-    apt -y install --no-install-recommends tailscale
 RUN mkdir -p /var/run/tailscale /var/cache/tailscale /var/lib/tailscale


### PR DESCRIPTION
MagicDNS support for containers where /etc/resolv.conf is a bind mount is being implemented on a development branch, build from that development branch to be able to iterate on testing it.

Once the support goes into an unstable build, we'll go back to pulling binaries from the unstable branch.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>